### PR TITLE
Adding prelude.rs and linked to lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod hotkeys_provider;
 pub mod types;
 pub mod use_hotkeys;
 pub mod macros;
+pub mod prelude;
 
 pub use use_hotkeys::{use_hotkeys_scoped, use_hotkeys_ref_scoped};
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,4 @@
+pub use crate::use_hotkeys::{use_hotkeys_scoped, use_hotkeys_ref_scoped};
+pub use crate::hotkeys_provider::{use_hotkeys_context, HotkeysContext, HotkeysProvider};
+pub use crate::{use_hotkeys, use_hotkeys_ref};
+


### PR DESCRIPTION
Adding prelude in reference to issue #15. 
app.rs in demo imports should be changed from
```rust
use leptos_hotkeys::{
    scopes, use_hotkeys,
    use_hotkeys::{use_hotkeys_ref_scoped, use_hotkeys_scoped},
    use_hotkeys_context, use_hotkeys_ref, HotkeysContext, HotkeysProvider,
};
```
to
```rust
use leptos_hotkeys::prelude::*;
```
Nixos won't build rn, so change and try building on your side after merge please - coding blind currently